### PR TITLE
BLET-27 upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,23 +78,23 @@ language agnostic, and ports to other languages are planned.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.49</version>
+      <version>1.61</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>1.7.26</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.1</version>
+      <version>1.2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -107,12 +107,12 @@ language agnostic, and ports to other languages are planned.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
+      <version>1.12</version>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/src/main/java/net/lshift/spki/suiteb/sexpstructs/ECPointConverter.java
+++ b/src/main/java/net/lshift/spki/suiteb/sexpstructs/ECPointConverter.java
@@ -38,8 +38,9 @@ public class ECPointConverter
 
     @Override
     public ECPointConverter.Point stepIn(final ECPoint q) {
+        final ECPoint normQ = q.normalize();
         return new Point(
-            q.getX().toBigInteger(), q.getY().toBigInteger());
+            normQ.getXCoord().toBigInteger(), normQ.getYCoord().toBigInteger());
     }
 
     @Override
@@ -47,8 +48,9 @@ public class ECPointConverter
         final ECCurve curve = Ec.DOMAIN_PARAMETERS.getCurve();
         final ECPoint res = curve.createPoint(
             point.x, point.y, false);
-        final ECFieldElement x = res.getX();
-        if (!res.getY().square().equals(
+        final ECPoint normRes = res.normalize();
+        final ECFieldElement x = normRes.getXCoord();
+        if (!normRes.getYCoord().square().equals(
             x.multiply(x.square().add(curve.getA())).add(curve.getB()))) {
             throw new CryptographyException("Point is not on curve");
         }


### PR DESCRIPTION
 - Upgrade everything reported by `mvn versions:display-dependency-updates` to the current latest stable version.
 - Follow Bouncycastle's api changes.
